### PR TITLE
chore: update import directory from shoelace to hotosm/ui exported shoelace UI and removed shoelace library

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,9 +14,8 @@
     "coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@hotosm/ui": "0.2.0-b4",
+    "@hotosm/ui": "^0.2.0-b6",
     "@reactour/tour": "^3.7.0",
-    "@shoelace-style/shoelace": "^2.16.0",
     "@tanstack/react-query": "^5.59.0",
     "@tanstack/react-query-devtools": "^5.59.0",
     "@tanstack/react-table": "^8.20.5",

--- a/frontend/src/components/ui/accordion/accordion.tsx
+++ b/frontend/src/components/ui/accordion/accordion.tsx
@@ -1,5 +1,5 @@
 import { ChevronDownIcon } from "@/components/ui/icons";
-import { SlDetails } from "@shoelace-style/shoelace/dist/react";
+import { Details as SlDetails } from "@hotosm/ui/components/react/index";
 import "./accordion.css";
 
 type AccordionProps = {

--- a/frontend/src/components/ui/avatar/avatar.tsx
+++ b/frontend/src/components/ui/avatar/avatar.tsx
@@ -1,5 +1,5 @@
 import { TCSSWithVars } from "@/types";
-import { SlAvatar } from "@shoelace-style/shoelace/dist/react";
+import { Avatar as SlAvatar } from "@hotosm/ui/components/react/index";
 
 export const Avatar = ({
   imageUrl,

--- a/frontend/src/components/ui/button/button.tsx
+++ b/frontend/src/components/ui/button/button.tsx
@@ -1,7 +1,7 @@
 import useScreenSize from "@/hooks/use-screen-size";
 import { ButtonSize } from "@/types";
 import { cn } from "@/utils";
-import { SlButton } from "@shoelace-style/shoelace/dist/react";
+import { Button as SlButton } from "@hotosm/ui/components/react/index";
 import { Spinner } from "@/components/ui/spinner";
 import "./button.css";
 import { ButtonVariant } from "@/enums";

--- a/frontend/src/components/ui/dialog/dialog.tsx
+++ b/frontend/src/components/ui/dialog/dialog.tsx
@@ -1,6 +1,6 @@
 import useScreenSize from "@/hooks/use-screen-size";
 import { SHOELACE_SIZES } from "@/enums";
-import { SlDialog } from "@shoelace-style/shoelace/dist/react";
+import { Dialog as SlDialog } from "@hotosm/ui/components/react/index";
 import "./dialog.css";
 
 type DialogProps = {

--- a/frontend/src/components/ui/drawer/drawer.tsx
+++ b/frontend/src/components/ui/drawer/drawer.tsx
@@ -1,5 +1,5 @@
 import { DrawerPlacements } from "@/enums";
-import { SlDrawer } from "@shoelace-style/shoelace/dist/react";
+import { Drawer as SlDrawer } from "@hotosm/ui/components/react/index";
 import "./drawer.css";
 
 type DrawerProps = {

--- a/frontend/src/components/ui/dropdown/dropdown.tsx
+++ b/frontend/src/components/ui/dropdown/dropdown.tsx
@@ -1,10 +1,10 @@
 import { ChevronDownIcon } from "@/components/ui/icons";
 import { cn } from "@/utils";
 import { DropdownPlacement } from "@/enums";
-import { SlCheckbox } from "@shoelace-style/shoelace/dist/react";
-import { SlDropdown } from "@shoelace-style/shoelace/dist/react";
-import { SlMenu } from "@shoelace-style/shoelace/dist/react";
-import { SlMenuItem } from "@shoelace-style/shoelace/dist/react";
+import { Checkbox as SlCheckbox } from "@hotosm/ui/components/react/index";
+import { Dropdown as SlDropdown } from "@hotosm/ui/components/react/index";
+import { Menu as SlMenu } from "@hotosm/ui/components/react/index";
+import { MenuItem as SlMenuItem } from "@hotosm/ui/components/react/index";
 import { useEffect, useState } from "react";
 import "./dropdown.css";
 

--- a/frontend/src/components/ui/form/checkbox-group/checkbox-group.tsx
+++ b/frontend/src/components/ui/form/checkbox-group/checkbox-group.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@/utils";
 import { SHOELACE_SIZES } from "@/enums";
-import { SlCheckbox } from "@shoelace-style/shoelace/dist/react/index.js";
+import { Checkbox as SlCheckbox } from "@hotosm/ui/components/react/index";
 import { useEffect, useState } from "react";
 import "./checkbox-group.css";
 

--- a/frontend/src/components/ui/form/input/input.tsx
+++ b/frontend/src/components/ui/form/input/input.tsx
@@ -5,7 +5,7 @@ import { CalenderIcon } from "@/components/ui/icons";
 import { CheckIcon } from "@/components/ui/icons";
 import { FormLabel, HelpText } from "@/components/ui/form";
 import { INPUT_TYPES, SHOELACE_SIZES } from "@/enums";
-import { SlInput } from "@shoelace-style/shoelace/dist/react";
+import { Input as SlInput } from "@hotosm/ui/components/react/index";
 import { useRef } from "react";
 
 type InputProps = {

--- a/frontend/src/components/ui/form/radio-group/radio-group.tsx
+++ b/frontend/src/components/ui/form/radio-group/radio-group.tsx
@@ -1,7 +1,7 @@
 import {
-  SlRadioGroup,
-  SlRadio,
-} from "@shoelace-style/shoelace/dist/react/index.js";
+  RadioGroup as SlRadioGroup,
+  Radio as SlRadio,
+} from "@hotosm/ui/components/react/index";
 import "./radio-group.css";
 import { ToolTip } from "@/components/ui/tooltip";
 

--- a/frontend/src/components/ui/form/select/select.tsx
+++ b/frontend/src/components/ui/form/select/select.tsx
@@ -1,7 +1,10 @@
 import useScreenSize from "@/hooks/use-screen-size";
 import { FormLabel, HelpText } from "@/components/ui/form";
 import { SHOELACE_SELECT_SIZES } from "@/enums";
-import { SlOption, SlSelect } from "@shoelace-style/shoelace/dist/react";
+import {
+  Option as SlOption,
+  Select as SlSelect,
+} from "@hotosm/ui/components/react/index";
 import { TShoelaceSize } from "@/types";
 import "./select.css";
 

--- a/frontend/src/components/ui/form/switch/switch.tsx
+++ b/frontend/src/components/ui/form/switch/switch.tsx
@@ -1,6 +1,6 @@
 import styles from "./switch.module.css";
 import { cn } from "@/utils";
-import { SlSwitch } from "@shoelace-style/shoelace/dist/react";
+import { Switch as SlSwitch } from "@hotosm/ui/components/react/index";
 
 type SwitchProps = {
   disabled?: boolean;

--- a/frontend/src/components/ui/form/text-area/text-area.tsx
+++ b/frontend/src/components/ui/form/text-area/text-area.tsx
@@ -1,5 +1,5 @@
 import { FormLabel, HelpText } from "@/components/ui/form";
-import { SlTextarea } from "@shoelace-style/shoelace/dist/react";
+import { Textarea as SlTextarea } from "@hotosm/ui/components/react/index";
 import "./text-area.css";
 
 type TextAreaProps = {

--- a/frontend/src/components/ui/popup/popup.tsx
+++ b/frontend/src/components/ui/popup/popup.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import SlPopup from "@shoelace-style/shoelace/dist/react/popup/index.js";
+import { Popup as SlPopup } from "@hotosm/ui/components/react/index";
 
 type PopupProps = {
   placement?: "top" | "bottom" | "bottom-start" | "bottom-end";

--- a/frontend/src/components/ui/spinner/spinner.tsx
+++ b/frontend/src/components/ui/spinner/spinner.tsx
@@ -1,4 +1,4 @@
-import { SlSpinner } from "@shoelace-style/shoelace/dist/react";
+import { Spinner as SlSpinner } from "@hotosm/ui/components/react/index";
 
 type SpinnerProps = {
   style?: Record<string, string>;

--- a/frontend/src/components/ui/tooltip/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip/tooltip.tsx
@@ -1,8 +1,8 @@
 import { InfoIcon } from "@/components/ui/icons";
 import { ToolTipPlacement } from "@/enums";
-import SlTooltip, {
-  SlHideEvent,
-} from "@shoelace-style/shoelace/dist/react/tooltip/index.js";
+import  {
+  Tooltip as SlTooltip,
+} from "@hotosm/ui/components/react/index";
 
 type ToolTipProps = {
   content?: string | React.ReactElement | null;
@@ -19,7 +19,7 @@ const ToolTip: React.FC<ToolTipProps> = ({
   placement = ToolTipPlacement.TOP,
   open,
 }) => {
-  const stopPropagations = (e: SlHideEvent) => {
+  const stopPropagations = (e: CustomEvent<Record<PropertyKey, never>>) => {
     e.stopImmediatePropagation();
     e.stopPropagation();
   };

--- a/frontend/src/features/model-creation/components/dialogs/file-upload-dialog.tsx
+++ b/frontend/src/features/model-creation/components/dialogs/file-upload-dialog.tsx
@@ -5,7 +5,7 @@ import { DialogProps, Feature, FeatureCollection } from "@/types";
 import { FileWithPath, useDropzone } from "react-dropzone";
 import { Geometry, MultiPolygon, Polygon } from "geojson";
 import { MODELS_CONTENT } from "@/constants";
-import { SlFormatBytes } from "@shoelace-style/shoelace/dist/react";
+import { FormatBytes as SlFormatBytes } from "@hotosm/ui/components/react/index";
 import { Spinner } from "@/components/ui/spinner";
 import { useCallback, useState } from "react";
 import {
@@ -259,7 +259,10 @@ const FileUploadDialog: React.FC<FileUploadDialogProps> = ({
                 <p className="text-dark text-body-3">
                   {truncateString(file.file.name)}
                 </p>
-                <SlFormatBytes value={file.file.size} className="text-sm" />
+                <SlFormatBytes
+                  value={file.file.size}
+                  className="text-sm"
+                />
               </div>
             </div>
             <button

--- a/frontend/src/features/models/components/directory-tree.tsx
+++ b/frontend/src/features/models/components/directory-tree.tsx
@@ -13,10 +13,10 @@ import { TCSSWithVars } from "@/types";
 import { useEffect, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import {
-  SlFormatBytes,
-  SlTree,
-  SlTreeItem,
-} from "@shoelace-style/shoelace/dist/react";
+  FormatBytes as SlFormatBytes,
+  Tree as SlTree,
+  TreeItem as SlTreeItem,
+} from "@hotosm/ui/components/react/index";
 import { ToolTip } from "@/components/ui/tooltip";
 import useCopyToClipboard from "@/hooks/use-clipboard";
 import { BASE_API_URL } from "@/config";

--- a/frontend/src/features/models/components/filters/date-range-filter.tsx
+++ b/frontend/src/features/models/components/filters/date-range-filter.tsx
@@ -2,7 +2,7 @@ import { DateFilter, TQueryParams } from "@/types";
 import { DateRangePicker } from "@/components/ui/form";
 import { DropDown } from "@/components/ui/dropdown";
 import { SEARCH_PARAMS } from "@/app/routes/models/models-list";
-import { SlCheckbox } from "@shoelace-style/shoelace/dist/react";
+import { Checkbox as SlCheckbox } from "@hotosm/ui/components/react/index";
 import { useDropdownMenu } from "@/hooks/use-dropdown-menu";
 import { useEffect, useState } from "react";
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,7 +7,6 @@ import { StrictMode } from "react";
 import "@/styles/hot-font-face.css";
 import '@hotosm/ui/dist/style.css';
 import "@/styles/index.css";
-import '@hotosm/ui/dist/components';
 import { MATOMO_APP_DOMAIN, MATOMO_ID } from "@/config";
 
 createRoot(document.getElementById("root")!).render(


### PR DESCRIPTION
**Description:**

Refactor component to use the HOT-exported Shoelace UI instead of the original Shoelace library. Remove the external Shoelace dependency.


NOTE: Still testing 